### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 This MCP server provides access to Lark Bitable through the Model Context Protocol. It allows users to interact with Bitable tables using predefined tools.
 
+<a href="https://glama.ai/mcp/servers/@lloydzhou/bitable-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lloydzhou/bitable-mcp/badge" alt="Bitable Server MCP server" />
+</a>
+
 ## One click installation & Configuration
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [Bitable MCP Server](https://glama.ai/mcp/servers/@lloydzhou/bitable-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lloydzhou/bitable-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lloydzhou/bitable-mcp/badge" alt="Bitable Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.